### PR TITLE
Handle workflow_dispatch in approval and checkout steps

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,7 +11,7 @@ _Put an `x` in the boxes that apply. You can also fill these out after creating 
 #### General
 
 - [ ] I have read the CONTRIBUTING doc
-- [ ] I certify that the changes I am introducing will be backword compatible
+- [ ] I certify that the changes I am introducing will be backward compatible
 - [ ] I used the commit message format described in CONTRIBUTING doc
 
 #### Tests

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -21,23 +21,29 @@ jobs:
         with:
           result-encoding: string
           script: |
+            // workflow_dispatch can only be triggered by collaborators, auto-approve
+            if (context.eventName === 'workflow_dispatch') {
+              console.log('workflow_dispatch trigger — auto-approving (requires repo write access)');
+              return "auto-approve"
+            }
             try {
+              const username = context.payload.pull_request.user.login;
               const permissionResponse = await github.rest.repos.getCollaboratorPermissionLevel({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                username: context.payload.pull_request.user.login,
+                username: username,
               });
               const permission = permissionResponse.data.permission;
               const hasWriteAccess = ['write', 'admin'].includes(permission);
               if (!hasWriteAccess) {
-                console.log(`User ${context.payload.pull_request.user.login} does not have write access (permission: ${permission})`);
+                console.log(`User ${username} does not have write access (permission: ${permission})`);
                 return "manual-approval"
               } else {
-                console.log(`Verified ${context.payload.pull_request.user.login} has write access. Auto Approving.`)
+                console.log(`Verified ${username} has write access. Auto Approving.`)
                 return "auto-approve"
               }
             } catch (error) {
-              console.log(`${context.payload.pull_request.user.login} does not have write access. Requiring Manual Approval.`)
+              console.log(`${context.payload.pull_request?.user?.login ?? context.actor} does not have write access. Requiring Manual Approval.`)
               return "manual-approval"
             }
 
@@ -78,7 +84,7 @@ jobs:
       - name: Checkout head commit
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Install SBT
         run: |
@@ -135,7 +141,7 @@ jobs:
       - name: Checkout head commit
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Install SBT
         run: |


### PR DESCRIPTION

*Description of changes:*

Add auto-approve path for workflow_dispatch events since they require repo write access. Extract username variable to reduce repetition in permission check. Use optional chaining in error handler fallback. Fall back to github.sha for checkout ref when not a pull_request event.


*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the CONTRIBUTING doc
- [x] I certify that the changes I am introducing will be backward compatible
- [x] I used the commit message format described in CONTRIBUTING doc

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have verified all code in this commit are well formatted

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.