### PR TITLE
ci: Build only Spark 3.5 JAR in integration-tests job

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -163,6 +163,8 @@ jobs:
           python-version: '3.10'
 
       - name: Install dependencies
+        env:
+          SPARK_BUILD_VERSION: "3.5"
         run: |
           python -m pip install --upgrade pip "setuptools<82" wheel
           pip install pyspark==3.5.1


### PR DESCRIPTION
The integration-tests job runs against PySpark 3.5.1 but `pip install .[integ]` was invoking setup.py without SPARK_BUILD_VERSION set, which triggers a build of every supported Spark JAR (3.1 through 3.5). The 3.1 build fails to resolve org.apache.spark:spark-hadoop-cloud_2.12: 3.1.3 because that artifact is not published to Maven Central (earliest published version is 3.2.0), causing the whole install step to fail.

Set SPARK_BUILD_VERSION=3.5 on the install step so only the 3.5 JAR is built, matching the pyspark version the job actually exercises. The subsequent Build step already sets the same env var.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.