### PR TITLE
feat: Wire BatchWriteRecord and ListRecords into ingest_data

### DIFF
--- a/pyspark-sdk/src/feature_store_pyspark/FeatureStoreManager.py
+++ b/pyspark-sdk/src/feature_store_pyspark/FeatureStoreManager.py
@@ -49,7 +49,7 @@ class FeatureStoreManager(SageMakerFeatureStoreJavaWrapper):
         self._java_obj = self._new_java_obj(FeatureStoreManager._wrapped_class, assume_role_arn)
 
     def ingest_data(self, input_data_frame: DataFrame, feature_group_arn: str, target_stores: List[str] = None,
-                    use_lake_formation_credentials: bool = False):
+                    use_lake_formation_credentials: bool = False, use_batch_write_record: bool = False):
         """
         Batch ingest data into SageMaker FeatureStore.
 
@@ -60,6 +60,10 @@ class FeatureStoreManager(SageMakerFeatureStoreJavaWrapper):
             Defaults to False. Requires PySpark 3.5 or newer; setting this to True on older
             PySpark versions will raise ``ValueError`` because the bundled Scala JAR for
             PySpark < 3.5 does not include Lake Formation support.
+        :param use_batch_write_record (bool): whether to use BatchWriteRecord API (25 records
+            per call) instead of PutRecord (1 record per call) for online store ingestion.
+            Requires both ``sagemaker:BatchWriteRecord`` AND ``sagemaker:PutRecord`` IAM
+            permissions. Defaults to False.
 
         :return:
         """
@@ -69,7 +73,7 @@ class FeatureStoreManager(SageMakerFeatureStoreJavaWrapper):
                 f"detected PySpark {pyspark.__version__}"
             )
         return self._call_java("ingestDataInJava", input_data_frame, feature_group_arn, target_stores,
-                               use_lake_formation_credentials)
+                               use_lake_formation_credentials, use_batch_write_record)
 
     def load_feature_definitions_from_schema(self, input_data_frame: DataFrame):
         """
@@ -92,3 +96,23 @@ class FeatureStoreManager(SageMakerFeatureStoreJavaWrapper):
         :return: the DataFrame of records that fail to be ingested.
         """
         return self._call_java("getFailedStreamIngestionDataFrame")
+
+    def list_records(self, feature_group_arn: str, max_results: int = None,
+                     next_token: str = None, include_soft_deleted_records: bool = False):
+        """
+        List record identifiers from a FeatureGroup's OnlineStore (single page).
+
+        :param feature_group_arn (str): ARN or name of the feature group.
+        :param max_results (int): maximum number of record identifiers per page (1-100).
+        :param next_token (str): pagination token from a previous response.
+        :param include_soft_deleted_records (bool): if True, include soft-deleted records.
+
+        :return: dict with 'RecordIdentifiers' (list of str) and 'NextToken' (str or None)
+        """
+        result = self._call_java("listRecords", feature_group_arn, max_results,
+                                 next_token, include_soft_deleted_records)
+        return {
+            "RecordIdentifiers": list(result["RecordIdentifiers"]),
+            "NextToken": result["NextToken"],
+        }
+

--- a/pyspark-sdk/tests/test_feature_store_manager.py
+++ b/pyspark-sdk/tests/test_feature_store_manager.py
@@ -26,13 +26,12 @@ def test_feature_store_manager_methods():
            "sparksdk.FeatureStoreManager"
 
     with patch('pyspark.ml.wrapper.JavaWrapper._call_java') as java_method_invocation:
-        # Default use_lake_formation_credentials=False. The Scala JAR always exposes the 4-arg
-        # ingestDataInJava, so the wrapper always forwards 4 args (including the LF flag=False).
+        # Default use_lake_formation_credentials=False, use_batch_write_record=False.
         feature_store_manager.ingest_data(None, "test-arn", ["OnlineStore"])
-        java_method_invocation.assert_called_with("ingestDataInJava", None, "test-arn", ["OnlineStore"], False)
+        java_method_invocation.assert_called_with("ingestDataInJava", None, "test-arn", ["OnlineStore"], False, False)
 
         feature_store_manager.ingest_data(None, "test-arn", ["OfflineStore"], use_lake_formation_credentials=False)
-        java_method_invocation.assert_called_with("ingestDataInJava", None, "test-arn", ["OfflineStore"], False)
+        java_method_invocation.assert_called_with("ingestDataInJava", None, "test-arn", ["OfflineStore"], False, False)
 
         feature_store_manager.get_failed_stream_ingestion_data_frame()
         java_method_invocation.assert_called_with("getFailedStreamIngestionDataFrame")
@@ -56,16 +55,16 @@ def test_ingest_data_lf_on_new_pyspark_calls_4_arg():
          patch('pyspark.ml.wrapper.JavaWrapper._call_java') as java_method_invocation:
         feature_store_manager.ingest_data(None, "test-arn", ["OfflineStore"],
                                           use_lake_formation_credentials=True)
-        java_method_invocation.assert_called_with("ingestDataInJava", None, "test-arn", ["OfflineStore"], True)
+        java_method_invocation.assert_called_with("ingestDataInJava", None, "test-arn", ["OfflineStore"], True, False)
 
 
 def test_ingest_data_no_lf_on_old_pyspark_calls_4_arg():
     feature_store_manager = FeatureStoreManager()
     with patch.object(fsm_module, "_is_pyspark_35_or_newer", return_value=False), \
          patch('pyspark.ml.wrapper.JavaWrapper._call_java') as java_method_invocation:
-        # Even on old PySpark the Scala JAR exposes the 4-arg method; the wrapper forwards False.
+        # Even on old PySpark the Scala JAR exposes the 5-arg method; the wrapper forwards False for both flags.
         feature_store_manager.ingest_data(None, "test-arn", ["OfflineStore"])
-        java_method_invocation.assert_called_with("ingestDataInJava", None, "test-arn", ["OfflineStore"], False)
+        java_method_invocation.assert_called_with("ingestDataInJava", None, "test-arn", ["OfflineStore"], False, False)
 
 
 def test_load_feature_definitions_from_schema():
@@ -92,3 +91,124 @@ def test_load_feature_definitions_from_schema():
             'FeatureType': 'String'
         },
     ]
+
+
+# ============================================================================
+# BatchWriteRecord (use_batch_write_record flag) tests
+# ============================================================================
+
+def test_ingest_data_batch_write_record_default_false():
+    """use_batch_write_record defaults to False, passes False to Java."""
+    feature_store_manager = FeatureStoreManager()
+    with patch('pyspark.ml.wrapper.JavaWrapper._call_java') as java_method_invocation:
+        feature_store_manager.ingest_data(None, "test-arn", ["OnlineStore"])
+        java_method_invocation.assert_called_with(
+            "ingestDataInJava", None, "test-arn", ["OnlineStore"], False, False
+        )
+
+
+def test_ingest_data_batch_write_record_true():
+    """use_batch_write_record=True passes True to Java."""
+    feature_store_manager = FeatureStoreManager()
+    with patch('pyspark.ml.wrapper.JavaWrapper._call_java') as java_method_invocation:
+        feature_store_manager.ingest_data(None, "test-arn", None, use_batch_write_record=True)
+        java_method_invocation.assert_called_with(
+            "ingestDataInJava", None, "test-arn", None, False, True
+        )
+
+
+def test_ingest_data_batch_write_record_false_explicit():
+    """use_batch_write_record=False explicitly passes False to Java."""
+    feature_store_manager = FeatureStoreManager()
+    with patch('pyspark.ml.wrapper.JavaWrapper._call_java') as java_method_invocation:
+        feature_store_manager.ingest_data(None, "test-arn", None, use_batch_write_record=False)
+        java_method_invocation.assert_called_with(
+            "ingestDataInJava", None, "test-arn", None, False, False
+        )
+
+
+def test_ingest_data_batch_write_with_lf_and_bwr():
+    """Both use_lake_formation_credentials=True and use_batch_write_record=True."""
+    feature_store_manager = FeatureStoreManager()
+    with patch.object(fsm_module, "_is_pyspark_35_or_newer", return_value=True), \
+         patch('pyspark.ml.wrapper.JavaWrapper._call_java') as java_method_invocation:
+        feature_store_manager.ingest_data(
+            None, "test-arn", ["OfflineStore"],
+            use_lake_formation_credentials=True,
+            use_batch_write_record=True,
+        )
+        java_method_invocation.assert_called_with(
+            "ingestDataInJava", None, "test-arn", ["OfflineStore"], True, True
+        )
+
+
+def test_ingest_data_batch_write_with_target_stores():
+    """target_stores + use_batch_write_record=True."""
+    feature_store_manager = FeatureStoreManager()
+    with patch('pyspark.ml.wrapper.JavaWrapper._call_java') as java_method_invocation:
+        feature_store_manager.ingest_data(
+            None, "test-arn", ["OnlineStore"],
+            use_batch_write_record=True,
+        )
+        java_method_invocation.assert_called_with(
+            "ingestDataInJava", None, "test-arn", ["OnlineStore"], False, True
+        )
+
+
+# ============================================================================
+# ListRecords tests
+# ============================================================================
+
+def test_list_records_basic():
+    """list_records calls Java with correct args and returns dict."""
+    feature_store_manager = FeatureStoreManager()
+    with patch('pyspark.ml.wrapper.JavaWrapper._call_java') as java_method_invocation:
+        mock_result = {"RecordIdentifiers": ["id1", "id2"], "NextToken": None}
+        java_method_invocation.return_value = mock_result
+        result = feature_store_manager.list_records("test-arn", max_results=10)
+        java_method_invocation.assert_called_with(
+            "listRecords", "test-arn", 10, None, False
+        )
+        assert result["RecordIdentifiers"] == ["id1", "id2"]
+        assert result["NextToken"] is None
+
+
+def test_list_records_with_next_token():
+    """list_records passes next_token correctly."""
+    feature_store_manager = FeatureStoreManager()
+    with patch('pyspark.ml.wrapper.JavaWrapper._call_java') as java_method_invocation:
+        mock_result = {"RecordIdentifiers": ["id3"], "NextToken": "token2"}
+        java_method_invocation.return_value = mock_result
+        result = feature_store_manager.list_records("test-arn", next_token="token1")
+        java_method_invocation.assert_called_with(
+            "listRecords", "test-arn", None, "token1", False
+        )
+        assert result["NextToken"] == "token2"
+
+
+def test_list_records_with_soft_deleted():
+    """list_records passes include_soft_deleted_records correctly."""
+    feature_store_manager = FeatureStoreManager()
+    with patch('pyspark.ml.wrapper.JavaWrapper._call_java') as java_method_invocation:
+        mock_result = {"RecordIdentifiers": ["id1"], "NextToken": None}
+        java_method_invocation.return_value = mock_result
+        result = feature_store_manager.list_records(
+            "test-arn", include_soft_deleted_records=True
+        )
+        java_method_invocation.assert_called_with(
+            "listRecords", "test-arn", None, None, True
+        )
+
+
+def test_list_records_all_params():
+    """list_records with all params."""
+    feature_store_manager = FeatureStoreManager()
+    with patch('pyspark.ml.wrapper.JavaWrapper._call_java') as java_method_invocation:
+        mock_result = {"RecordIdentifiers": [], "NextToken": None}
+        java_method_invocation.return_value = mock_result
+        result = feature_store_manager.list_records(
+            "test-arn", max_results=5, next_token="abc", include_soft_deleted_records=True
+        )
+        java_method_invocation.assert_called_with(
+            "listRecords", "test-arn", 5, "abc", True
+        )

--- a/scala-spark-sdk/build.sbt
+++ b/scala-spark-sdk/build.sbt
@@ -32,7 +32,7 @@ val sparkMinor = sparkVersionParts(1)
 def sparkVersionAtLeast(major: Int, minor: Int): Boolean =
   sparkMajor > major || (sparkMajor == major && sparkMinor >= minor)
 
-val awsSDKVersion = "2.18.32"
+val awsSDKVersion = "2.46.18"
 val sparkVersionToHadoopVersionMap = Map(
   "3.1" -> "3.2.4",
   "3.2" -> "3.2.4",
@@ -89,6 +89,7 @@ libraryDependencies ++= Seq(
   "software.amazon.awssdk" % "kms" % awsSDKVersion,
   "software.amazon.awssdk" % "sts" % awsSDKVersion,
   "software.amazon.awssdk" % "url-connection-client" % awsSDKVersion,
+  "software.amazon.awssdk" % "apache-client" % awsSDKVersion,
 
   "org.apache.iceberg" %% s"iceberg-spark-runtime-$majorSparkVersion" % icebergVersion,
 
@@ -128,6 +129,9 @@ assembly / assemblyShadeRules := Seq(
   ShadeRule.rename("org.apache.http.**" -> "smfs.shaded.org.apache.hc.@1").inAll,
   ShadeRule.rename("org.apache.iceberg.**" -> "smfs.shaded.org.apache.iceberg.@1").inAll,
 )
+
+// Exclude the SDK's netty-nio-client to avoid conflicts with Spark's bundled Netty
+excludeDependencies += ExclusionRule("software.amazon.awssdk", "netty-nio-client")
 
 exportJars := true
 lazy val printClasspath = taskKey[Unit]("Dump classpath")

--- a/scala-spark-sdk/src/main/scala/software/amazon/sagemaker/featurestore/sparksdk/FeatureStoreManager.scala
+++ b/scala-spark-sdk/src/main/scala/software/amazon/sagemaker/featurestore/sparksdk/FeatureStoreManager.scala
@@ -41,7 +41,14 @@ import software.amazon.awssdk.services.sagemaker.model.{
   FeatureType
 }
 import software.amazon.awssdk.services.sagemakerfeaturestoreruntime.SageMakerFeatureStoreRuntimeClient
-import software.amazon.awssdk.services.sagemakerfeaturestoreruntime.model.{FeatureValue, PutRecordRequest, TargetStore}
+import software.amazon.awssdk.services.sagemakerfeaturestoreruntime.model.{
+  BatchWriteRecordEntry,
+  BatchWriteRecordRequest,
+  FeatureValue,
+  ListRecordsRequest,
+  PutRecordRequest,
+  TargetStore
+}
 import org.slf4j.LoggerFactory
 import software.amazon.sagemaker.featurestore.sparksdk.exceptions.{StreamIngestionFailureException, ValidationError}
 import software.amazon.sagemaker.featurestore.sparksdk.helpers.{
@@ -86,16 +93,21 @@ class FeatureStoreManager(assumeRoleArn: String = null) extends Serializable {
    *    choose the target store to ingest the data
    *  @param useLakeFormationCredentials
    *    whether to use LakeFormation for offline store ingestion (default: false)
+   *  @param useBatchWriteRecord
+   *    whether to use BatchWriteRecord API (25 records per call) instead of PutRecord (1 record per call) for online
+   *    store ingestion. Requires both sagemaker:BatchWriteRecord AND sagemaker:PutRecord IAM permissions. (default:
+   *    false)
    */
   def ingestData(
       inputDataFrame: DataFrame,
       featureGroupArn: String,
       targetStores: List[String] = null,
-      useLakeFormationCredentials: Boolean = false
+      useLakeFormationCredentials: Boolean = false,
+      useBatchWriteRecord: Boolean = false
   ): Unit = {
 
     logger.info(
-      s"ingestData: featureGroupArn=$featureGroupArn, targetStores=$targetStores, useLakeFormationCredentials=$useLakeFormationCredentials"
+      s"ingestData: featureGroupArn=$featureGroupArn, targetStores=$targetStores, useLakeFormationCredentials=$useLakeFormationCredentials, useBatchWriteRecord=$useBatchWriteRecord"
     )
 
     val featureGroupArnResolver = new FeatureGroupArnResolver(featureGroupArn)
@@ -115,7 +127,7 @@ class FeatureStoreManager(assumeRoleArn: String = null) extends Serializable {
 
     if (parsedTargetStores == null || shouldIngestInStream(parsedTargetStores)) {
       validateSchemaNames(inputDataFrame.schema.names, describeResponse, recordIdentifierName, eventTimeFeatureName)
-      streamIngestIntoOnlineStore(featureGroupName, inputDataFrame, parsedTargetStores, region)
+      streamIngestIntoOnlineStore(featureGroupName, inputDataFrame, parsedTargetStores, region, useBatchWriteRecord)
     } else {
 
       val validatedInputDataFrame = validateInputDataFrame(inputDataFrame, describeResponse)
@@ -135,13 +147,15 @@ class FeatureStoreManager(assumeRoleArn: String = null) extends Serializable {
       inputDataFrame: org.apache.spark.sql.Dataset[Row],
       featureGroupArn: java.lang.String,
       targetStores: java.util.ArrayList[String] = null,
-      useLakeFormationCredentials: java.lang.Boolean = false
+      useLakeFormationCredentials: java.lang.Boolean = false,
+      useBatchWriteRecord: java.lang.Boolean = false
   ): Unit = {
     ingestData(
       inputDataFrame,
       featureGroupArn,
       if (targetStores != null) targetStores.asScala.toList else null,
-      Option(useLakeFormationCredentials).map(_.booleanValue()).getOrElse(false)
+      Option(useLakeFormationCredentials).map(_.booleanValue()).getOrElse(false),
+      Option(useBatchWriteRecord).map(_.booleanValue()).getOrElse(false)
     )
   }
 
@@ -181,11 +195,52 @@ class FeatureStoreManager(assumeRoleArn: String = null) extends Serializable {
     failedStreamIngestionDataFrame.orNull
   }
 
+  /** List record identifiers from a FeatureGroup's OnlineStore (single page).
+   *
+   *  @param featureGroupArn
+   *    ARN or name of the feature group
+   *  @param maxResults
+   *    maximum number of record identifiers to return (1-100)
+   *  @param nextToken
+   *    pagination token from a previous response
+   *  @param includeSoftDeletedRecords
+   *    if true, include soft-deleted records
+   *  @return
+   *    tuple of (list of record identifier strings, nextToken or null)
+   */
+  def listRecords(
+      featureGroupArn: String,
+      maxResults: java.lang.Integer = null,
+      nextToken: String = null,
+      includeSoftDeletedRecords: Boolean = false
+  ): java.util.Map[String, Object] = {
+    val featureGroupName = featureGroupArn
+    val region           = new FeatureGroupArnResolver(featureGroupArn).resolveRegion()
+    ClientFactory.initialize(region = region, roleArn = assumeRoleArn)
+
+    val requestBuilder = ListRecordsRequest
+      .builder()
+      .featureGroupName(featureGroupName)
+      .includeSoftDeletedRecords(includeSoftDeletedRecords)
+
+    if (maxResults != null) requestBuilder.maxResults(maxResults)
+    if (nextToken != null) requestBuilder.nextToken(nextToken)
+
+    val client   = ClientFactory.sageMakerFeatureStoreRuntimeClientBuilder.build()
+    val response = client.listRecords(requestBuilder.build())
+
+    val result = new java.util.HashMap[String, Object]()
+    result.put("RecordIdentifiers", response.recordIdentifiers())
+    result.put("NextToken", response.nextToken())
+    result
+  }
+
   private def streamIngestIntoOnlineStore(
       featureGroupName: String,
       inputDataFrame: DataFrame,
       targetStores: List[TargetStore],
-      region: String
+      region: String,
+      useBatchWriteRecord: Boolean = false
   ): Unit = {
     val columns                = inputDataFrame.schema.names
     val repartitionedDataFrame = DataFrameRepartitioner.repartition(inputDataFrame)
@@ -196,6 +251,13 @@ class FeatureStoreManager(assumeRoleArn: String = null) extends Serializable {
     )
     val fieldIndexMap = castWithExceptionSchema.fieldNames.zipWithIndex.toMap
 
+    if (useBatchWriteRecord) {
+      logger.info(
+        s"Using BatchWriteRecord API (batch_size=25). " +
+          s"Requires sagemaker:BatchWriteRecord AND sagemaker:PutRecord IAM permissions."
+      )
+    }
+
     // Encoder needs to be defined during transformation because the original schema is changed.
     // The dataframe has to be cached otherwise the input dataset will be re-ingested when customer perform spark
     // actions on failedStreamIngestionDataFrame.
@@ -204,13 +266,23 @@ class FeatureStoreManager(assumeRoleArn: String = null) extends Serializable {
         .mapPartitions(partition => {
           ClientFactory.initialize(region, assumeRoleArn)
 
-          putOnlineRecordsForPartition(
-            partition,
-            featureGroupName,
-            columns,
-            targetStores,
-            ClientFactory.sageMakerFeatureStoreRuntimeClientBuilder.build()
-          )
+          if (useBatchWriteRecord) {
+            batchWriteOnlineRecordsForPartition(
+              partition,
+              featureGroupName,
+              columns,
+              targetStores,
+              ClientFactory.sageMakerFeatureStoreRuntimeClientBuilder.build()
+            )
+          } else {
+            putOnlineRecordsForPartition(
+              partition,
+              featureGroupName,
+              columns,
+              targetStores,
+              ClientFactory.sageMakerFeatureStoreRuntimeClientBuilder.build()
+            )
+          }
         })(SparkRowEncoderAdaptor.encoderFor(castWithExceptionSchema))
         .filter(row => row.getAs[String](fieldIndexMap(ONLINE_INGESTION_ERROR_FILED_NAME)) != null)
         .cache()
@@ -270,6 +342,109 @@ class FeatureStoreManager(assumeRoleArn: String = null) extends Serializable {
     })
 
     newPartition
+  }
+
+  private val BATCH_WRITE_MAX_ENTRIES = 25
+
+  private def batchWriteOnlineRecordsForPartition(
+      partition: Iterator[Row],
+      featureGroupName: String,
+      columns: Array[String],
+      targetStores: List[TargetStore],
+      runTimeClient: SageMakerFeatureStoreRuntimeClient
+  ): Iterator[Row] = {
+    val results = ListBuffer[Row]()
+
+    partition.grouped(BATCH_WRITE_MAX_ENTRIES).foreach { batch =>
+      val batchRows = batch.toList
+      val entries   = ListBuffer[BatchWriteRecordEntry]()
+
+      batchRows.foreach { row =>
+        val record = ListBuffer[FeatureValue]()
+        columns.foreach { columnName =>
+          try {
+            if (!row.isNullAt(row.fieldIndex(columnName))) {
+              val featureValue = row.getAs[Any](columnName)
+              record += FeatureValue
+                .builder()
+                .featureName(columnName)
+                .valueAsString(featureValue.toString)
+                .build()
+            }
+          } catch {
+            case e: Throwable => throw new RuntimeException(e)
+          }
+        }
+
+        val entryBuilder = BatchWriteRecordEntry
+          .builder()
+          .featureGroupName(featureGroupName)
+          .record(record.asJava)
+
+        if (targetStores != null) {
+          entryBuilder.targetStores(targetStores.asJava)
+        }
+
+        entries += entryBuilder.build()
+      }
+
+      Try {
+        val request = BatchWriteRecordRequest
+          .builder()
+          .entries(entries.asJava)
+          .build()
+        runTimeClient.batchWriteRecord(request)
+      } match {
+        case Success(response) =>
+          // Build a set of failed entry indices by matching error.entry() and unprocessedEntries
+          val failedEntryIndices = scala.collection.mutable.Set[Int]()
+
+          // Map errors back to specific entries
+          val errorEntries = response.errors().asScala
+          errorEntries.foreach { error =>
+            val failedEntry = error.entry()
+            val idx         = entries.indexOf(failedEntry)
+            if (idx >= 0) {
+              failedEntryIndices += idx
+            } else {
+              logger.warn(s"Could not match error entry back to original batch: $failedEntry")
+            }
+          }
+
+          // Map unprocessed entries back to specific entries
+          val unprocessed = response.unprocessedEntries().asScala
+          unprocessed.foreach { entry =>
+            val idx = entries.indexOf(entry)
+            if (idx >= 0) {
+              failedEntryIndices += idx
+            } else {
+              logger.warn(s"Could not match unprocessed entry back to original batch: $entry")
+            }
+          }
+
+          // Mark only failed rows with error, successful rows get null
+          batchRows.zipWithIndex.foreach { case (row, idx) =>
+            val errorMessage = if (failedEntryIndices.contains(idx)) {
+              val errorDetail = errorEntries
+                .find(e => entries.indexOf(e.entry()) == idx)
+                .map(e => s"${e.errorCode()}: ${e.errorMessage()}")
+                .getOrElse("Unprocessed entry")
+              errorDetail
+            } else {
+              null
+            }
+            results += Row.fromSeq(row.toSeq.toList :+ errorMessage)
+          }
+
+        case Failure(ex) =>
+          // Entire batch failed — mark all rows with the exception message
+          batchRows.foreach { row =>
+            results += Row.fromSeq(row.toSeq.toList :+ ex.getMessage)
+          }
+      }
+    }
+
+    results.iterator
   }
 
   private def batchIngestIntoOfflineStore(

--- a/scala-spark-sdk/src/test/scala/software/amazon/sagemaker/featurestore/sparksdk/FeatureStoreManagerTest.scala
+++ b/scala-spark-sdk/src/test/scala/software/amazon/sagemaker/featurestore/sparksdk/FeatureStoreManagerTest.scala
@@ -27,7 +27,13 @@ import software.amazon.awssdk.services.sagemaker.model.{
   TableFormat
 }
 import software.amazon.awssdk.services.sagemakerfeaturestoreruntime.model.{
+  BatchWriteRecordEntry,
+  BatchWriteRecordError,
+  BatchWriteRecordRequest,
+  BatchWriteRecordResponse,
   FeatureValue,
+  ListRecordsRequest,
+  ListRecordsResponse,
   PutRecordRequest,
   PutRecordResponse,
   TargetStore
@@ -68,9 +74,27 @@ class FeatureStoreManagerTest extends TestNGSuite with PrivateMethodTester {
     ClientFactory.sageMakerClient = mockedSageMakerClient
     ClientFactory.sageMakerFeatureStoreRuntimeClientBuilder = mockedSageMakerFeatureStoreRuntimeClientBuilder
 
+    org.mockito.Mockito.reset(mockedSageMakerFeatureStoreRuntimeClient)
+    org.mockito.Mockito.reset(mockedSageMakerClient)
+
     when(mockedSageMakerFeatureStoreRuntimeClientBuilder.build()).thenReturn(mockedSageMakerFeatureStoreRuntimeClient)
     when(mockedSageMakerFeatureStoreRuntimeClient.putRecord(any(classOf[PutRecordRequest])))
       .thenReturn(PutRecordResponse.builder().build())
+    when(mockedSageMakerFeatureStoreRuntimeClient.batchWriteRecord(any(classOf[BatchWriteRecordRequest])))
+      .thenReturn(
+        BatchWriteRecordResponse
+          .builder()
+          .errors(java.util.Collections.emptyList[BatchWriteRecordError]())
+          .unprocessedEntries(java.util.Collections.emptyList[BatchWriteRecordEntry]())
+          .build()
+      )
+    when(mockedSageMakerFeatureStoreRuntimeClient.listRecords(any(classOf[ListRecordsRequest])))
+      .thenReturn(
+        ListRecordsResponse
+          .builder()
+          .recordIdentifiers(java.util.Arrays.asList("id-1", "id-2"))
+          .build()
+      )
   }
 
   @Test(dataProvider = "ingestDataStreamOnlineStoreTestDataProvider")
@@ -393,6 +417,375 @@ class FeatureStoreManagerTest extends TestNGSuite with PrivateMethodTester {
       inputDataFrame: DataFrame
   ): Unit = {
     featureStoreManager.loadFeatureDefinitionsFromSchema(inputDataFrame)
+  }
+
+  @Test
+  def ingestDataStreamOnlineStoreWithBatchWriteRecordTest(): Unit = {
+    val inputDataFrame = Seq(
+      ("identifier-1", "2021-05-06T05:12:14Z"),
+      ("identifier-2", "2021-05-06T05:12:14Z")
+    ).toDF("record-identifier", "event-time")
+
+    val response = DescribeFeatureGroupResponse
+      .builder()
+      .featureGroupArn(TEST_FEATURE_GROUP_ARN)
+      .featureGroupStatus(FeatureGroupStatus.CREATED)
+      .eventTimeFeatureName("event-time")
+      .recordIdentifierFeatureName("record-identifier")
+      .featureDefinitions(
+        FeatureDefinition.builder().featureName("record-identifier").featureType(FeatureType.STRING).build(),
+        FeatureDefinition.builder().featureName("event-time").featureType(FeatureType.STRING).build()
+      )
+      .onlineStoreConfig(OnlineStoreConfig.builder().enableOnlineStore(true).build())
+      .build()
+
+    when(mockedSageMakerClient.describeFeatureGroup(any(classOf[DescribeFeatureGroupRequest]))).thenReturn(response)
+
+    featureStoreManager.ingestData(
+      inputDataFrame,
+      TEST_FEATURE_GROUP_ARN,
+      List("OnlineStore"),
+      useLakeFormationCredentials = false,
+      useBatchWriteRecord = true
+    )
+
+    verify(mockedSageMakerFeatureStoreRuntimeClient, org.mockito.Mockito.atLeastOnce())
+      .batchWriteRecord(any(classOf[BatchWriteRecordRequest]))
+    verify(mockedSageMakerFeatureStoreRuntimeClient, times(0)).putRecord(any(classOf[PutRecordRequest]))
+
+    val failedDf = featureStoreManager.getFailedStreamIngestionDataFrame
+    assertEquals(failedDf.count(), 0)
+  }
+
+  @Test
+  def ingestDataStreamOnlineStoreWithBatchWriteRecordPartialFailureTest(): Unit = {
+    val inputDataFrame = Seq(
+      ("identifier-1", "2021-05-06T05:12:14Z"),
+      ("identifier-2", "2021-05-06T05:12:14Z")
+    ).toDF("record-identifier", "event-time")
+
+    val failedEntry = BatchWriteRecordEntry
+      .builder()
+      .featureGroupName(TEST_FEATURE_GROUP_ARN)
+      .record(
+        java.util.Arrays.asList(
+          FeatureValue.builder().featureName("record-identifier").valueAsString("identifier-2").build(),
+          FeatureValue.builder().featureName("event-time").valueAsString("2021-05-06T05:12:14Z").build()
+        )
+      )
+      .targetStores(java.util.Arrays.asList(TargetStore.ONLINE_STORE))
+      .build()
+
+    val errorResponse = BatchWriteRecordResponse
+      .builder()
+      .errors(
+        java.util.Arrays.asList(
+          BatchWriteRecordError
+            .builder()
+            .entry(failedEntry)
+            .errorCode("ValidationError")
+            .errorMessage("Test validation error")
+            .build()
+        )
+      )
+      .unprocessedEntries(java.util.Collections.emptyList[BatchWriteRecordEntry]())
+      .build()
+
+    when(mockedSageMakerFeatureStoreRuntimeClient.batchWriteRecord(any(classOf[BatchWriteRecordRequest])))
+      .thenReturn(errorResponse)
+
+    val response = DescribeFeatureGroupResponse
+      .builder()
+      .featureGroupArn(TEST_FEATURE_GROUP_ARN)
+      .featureGroupStatus(FeatureGroupStatus.CREATED)
+      .eventTimeFeatureName("event-time")
+      .recordIdentifierFeatureName("record-identifier")
+      .featureDefinitions(
+        FeatureDefinition.builder().featureName("record-identifier").featureType(FeatureType.STRING).build(),
+        FeatureDefinition.builder().featureName("event-time").featureType(FeatureType.STRING).build()
+      )
+      .onlineStoreConfig(OnlineStoreConfig.builder().enableOnlineStore(true).build())
+      .build()
+
+    when(mockedSageMakerClient.describeFeatureGroup(any(classOf[DescribeFeatureGroupRequest]))).thenReturn(response)
+
+    val caught = intercept[StreamIngestionFailureException] {
+      featureStoreManager.ingestData(
+        inputDataFrame,
+        TEST_FEATURE_GROUP_ARN,
+        List("OnlineStore"),
+        useLakeFormationCredentials = false,
+        useBatchWriteRecord = true
+      )
+    }
+
+    caught.message.contains("records failed to be ingested") shouldBe true
+
+    val failedDf = featureStoreManager.getFailedStreamIngestionDataFrame
+    // Verify exactly 1 row failed (identifier-2), not both
+    assertEquals(failedDf.count(), 1L)
+    // Verify the correct row (identifier-2) is in the failed DataFrame
+    val failedRow = failedDf.first()
+    assertEquals(failedRow.getAs[String]("record-identifier"), "identifier-2")
+    // Verify the error message is captured
+    assertEquals(failedRow.getAs[String]("online_ingestion_error"), "ValidationError: Test validation error")
+  }
+
+  @Test
+  def ingestDataStreamOnlineStoreWithBatchWriteRecordPartialFailureMultiRowTest(): Unit = {
+    // 5 records: only record at index 2 (identifier-3) fails
+    val inputDataFrame = Seq(
+      ("identifier-1", "2021-05-06T05:12:14Z"),
+      ("identifier-2", "2021-05-06T05:12:14Z"),
+      ("identifier-3", "2021-05-06T05:12:14Z"),
+      ("identifier-4", "2021-05-06T05:12:14Z"),
+      ("identifier-5", "2021-05-06T05:12:14Z")
+    ).toDF("record-identifier", "event-time")
+
+    val failedEntry = BatchWriteRecordEntry
+      .builder()
+      .featureGroupName(TEST_FEATURE_GROUP_ARN)
+      .record(
+        java.util.Arrays.asList(
+          FeatureValue.builder().featureName("record-identifier").valueAsString("identifier-3").build(),
+          FeatureValue.builder().featureName("event-time").valueAsString("2021-05-06T05:12:14Z").build()
+        )
+      )
+      .targetStores(java.util.Arrays.asList(TargetStore.ONLINE_STORE))
+      .build()
+
+    val errorResponse = BatchWriteRecordResponse
+      .builder()
+      .errors(
+        java.util.Arrays.asList(
+          BatchWriteRecordError
+            .builder()
+            .entry(failedEntry)
+            .errorCode("InternalError")
+            .errorMessage("Internal service error")
+            .build()
+        )
+      )
+      .unprocessedEntries(java.util.Collections.emptyList[BatchWriteRecordEntry]())
+      .build()
+
+    when(mockedSageMakerFeatureStoreRuntimeClient.batchWriteRecord(any(classOf[BatchWriteRecordRequest])))
+      .thenReturn(errorResponse)
+
+    val response = DescribeFeatureGroupResponse
+      .builder()
+      .featureGroupArn(TEST_FEATURE_GROUP_ARN)
+      .featureGroupStatus(FeatureGroupStatus.CREATED)
+      .eventTimeFeatureName("event-time")
+      .recordIdentifierFeatureName("record-identifier")
+      .featureDefinitions(
+        FeatureDefinition.builder().featureName("record-identifier").featureType(FeatureType.STRING).build(),
+        FeatureDefinition.builder().featureName("event-time").featureType(FeatureType.STRING).build()
+      )
+      .onlineStoreConfig(OnlineStoreConfig.builder().enableOnlineStore(true).build())
+      .build()
+
+    when(mockedSageMakerClient.describeFeatureGroup(any(classOf[DescribeFeatureGroupRequest]))).thenReturn(response)
+
+    val caught = intercept[StreamIngestionFailureException] {
+      featureStoreManager.ingestData(
+        inputDataFrame,
+        TEST_FEATURE_GROUP_ARN,
+        List("OnlineStore"),
+        useLakeFormationCredentials = false,
+        useBatchWriteRecord = true
+      )
+    }
+
+    caught.message.contains("records failed to be ingested") shouldBe true
+
+    val failedDf = featureStoreManager.getFailedStreamIngestionDataFrame
+    // Only 1 out of 5 should fail
+    assertEquals(failedDf.count(), 1L)
+    // Verify it's specifically identifier-3 (index 2 in the batch)
+    val failedRow = failedDf.first()
+    assertEquals(failedRow.getAs[String]("record-identifier"), "identifier-3")
+    assertEquals(failedRow.getAs[String]("online_ingestion_error"), "InternalError: Internal service error")
+  }
+
+  @Test
+  def ingestDataStreamOnlineStoreWithBatchWriteRecordMultipleFailuresTest(): Unit = {
+    // 5 records: indices 1 (identifier-2) and 3 (identifier-4) fail
+    val inputDataFrame = Seq(
+      ("identifier-1", "2021-05-06T05:12:14Z"),
+      ("identifier-2", "2021-05-06T05:12:14Z"),
+      ("identifier-3", "2021-05-06T05:12:14Z"),
+      ("identifier-4", "2021-05-06T05:12:14Z"),
+      ("identifier-5", "2021-05-06T05:12:14Z")
+    ).toDF("record-identifier", "event-time")
+
+    val failedEntry1 = BatchWriteRecordEntry
+      .builder()
+      .featureGroupName(TEST_FEATURE_GROUP_ARN)
+      .record(
+        java.util.Arrays.asList(
+          FeatureValue.builder().featureName("record-identifier").valueAsString("identifier-2").build(),
+          FeatureValue.builder().featureName("event-time").valueAsString("2021-05-06T05:12:14Z").build()
+        )
+      )
+      .targetStores(java.util.Arrays.asList(TargetStore.ONLINE_STORE))
+      .build()
+
+    val failedEntry2 = BatchWriteRecordEntry
+      .builder()
+      .featureGroupName(TEST_FEATURE_GROUP_ARN)
+      .record(
+        java.util.Arrays.asList(
+          FeatureValue.builder().featureName("record-identifier").valueAsString("identifier-4").build(),
+          FeatureValue.builder().featureName("event-time").valueAsString("2021-05-06T05:12:14Z").build()
+        )
+      )
+      .targetStores(java.util.Arrays.asList(TargetStore.ONLINE_STORE))
+      .build()
+
+    val errorResponse = BatchWriteRecordResponse
+      .builder()
+      .errors(
+        java.util.Arrays.asList(
+          BatchWriteRecordError
+            .builder()
+            .entry(failedEntry1)
+            .errorCode("ValidationError")
+            .errorMessage("Error on record 2")
+            .build(),
+          BatchWriteRecordError
+            .builder()
+            .entry(failedEntry2)
+            .errorCode("InternalError")
+            .errorMessage("Error on record 4")
+            .build()
+        )
+      )
+      .unprocessedEntries(java.util.Collections.emptyList[BatchWriteRecordEntry]())
+      .build()
+
+    when(mockedSageMakerFeatureStoreRuntimeClient.batchWriteRecord(any(classOf[BatchWriteRecordRequest])))
+      .thenReturn(errorResponse)
+
+    val response = DescribeFeatureGroupResponse
+      .builder()
+      .featureGroupArn(TEST_FEATURE_GROUP_ARN)
+      .featureGroupStatus(FeatureGroupStatus.CREATED)
+      .eventTimeFeatureName("event-time")
+      .recordIdentifierFeatureName("record-identifier")
+      .featureDefinitions(
+        FeatureDefinition.builder().featureName("record-identifier").featureType(FeatureType.STRING).build(),
+        FeatureDefinition.builder().featureName("event-time").featureType(FeatureType.STRING).build()
+      )
+      .onlineStoreConfig(OnlineStoreConfig.builder().enableOnlineStore(true).build())
+      .build()
+
+    when(mockedSageMakerClient.describeFeatureGroup(any(classOf[DescribeFeatureGroupRequest]))).thenReturn(response)
+
+    val caught = intercept[StreamIngestionFailureException] {
+      featureStoreManager.ingestData(
+        inputDataFrame,
+        TEST_FEATURE_GROUP_ARN,
+        List("OnlineStore"),
+        useLakeFormationCredentials = false,
+        useBatchWriteRecord = true
+      )
+    }
+
+    caught.message.contains("records failed to be ingested") shouldBe true
+
+    val failedDf = featureStoreManager.getFailedStreamIngestionDataFrame
+    // Exactly 2 out of 5 should fail
+    assertEquals(failedDf.count(), 2L)
+    // Verify the correct rows failed (identifier-2 and identifier-4)
+    val failedIds = failedDf.collect().map(_.getAs[String]("record-identifier")).sorted
+    assertEquals(failedIds.toList, List("identifier-2", "identifier-4"))
+    // Verify error messages are correct
+    val failedErrors = failedDf
+      .collect()
+      .map(row => (row.getAs[String]("record-identifier"), row.getAs[String]("online_ingestion_error")))
+      .toMap
+    assertEquals(failedErrors("identifier-2"), "ValidationError: Error on record 2")
+    assertEquals(failedErrors("identifier-4"), "InternalError: Error on record 4")
+  }
+
+  @Test
+  def ingestDataStreamOnlineStoreWithBatchWriteRecordFullFailureTest(): Unit = {
+    val inputDataFrame = Seq(
+      ("identifier-1", "2021-05-06T05:12:14Z")
+    ).toDF("record-identifier", "event-time")
+
+    when(mockedSageMakerFeatureStoreRuntimeClient.batchWriteRecord(any(classOf[BatchWriteRecordRequest])))
+      .thenThrow(new RuntimeException("batch write error"))
+
+    val response = DescribeFeatureGroupResponse
+      .builder()
+      .featureGroupArn(TEST_FEATURE_GROUP_ARN)
+      .featureGroupStatus(FeatureGroupStatus.CREATED)
+      .eventTimeFeatureName("event-time")
+      .recordIdentifierFeatureName("record-identifier")
+      .featureDefinitions(
+        FeatureDefinition.builder().featureName("record-identifier").featureType(FeatureType.STRING).build(),
+        FeatureDefinition.builder().featureName("event-time").featureType(FeatureType.STRING).build()
+      )
+      .onlineStoreConfig(OnlineStoreConfig.builder().enableOnlineStore(true).build())
+      .build()
+
+    when(mockedSageMakerClient.describeFeatureGroup(any(classOf[DescribeFeatureGroupRequest]))).thenReturn(response)
+
+    val caught = intercept[StreamIngestionFailureException] {
+      featureStoreManager.ingestData(
+        inputDataFrame,
+        TEST_FEATURE_GROUP_ARN,
+        List("OnlineStore"),
+        useLakeFormationCredentials = false,
+        useBatchWriteRecord = true
+      )
+    }
+
+    val failedDf = featureStoreManager.getFailedStreamIngestionDataFrame
+    assertEquals(failedDf.count(), 1)
+    assertEquals(failedDf.first().getAs[String]("online_ingestion_error"), "batch write error")
+  }
+
+  @Test
+  def listRecordsTest(): Unit = {
+    val result = featureStoreManager.listRecords(TEST_FEATURE_GROUP_ARN, maxResults = 10)
+
+    verify(mockedSageMakerFeatureStoreRuntimeClient, org.mockito.Mockito.atLeastOnce())
+      .listRecords(any(classOf[ListRecordsRequest]))
+    val identifiers = result.get("RecordIdentifiers").asInstanceOf[java.util.List[String]]
+    assertEquals(identifiers.size(), 2)
+    assertEquals(identifiers.get(0), "id-1")
+    assertEquals(identifiers.get(1), "id-2")
+  }
+
+  @Test
+  def listRecordsWithNextTokenTest(): Unit = {
+    val responseWithToken = ListRecordsResponse
+      .builder()
+      .recordIdentifiers(java.util.Arrays.asList("id-1"))
+      .nextToken("next-page-token")
+      .build()
+
+    when(mockedSageMakerFeatureStoreRuntimeClient.listRecords(any(classOf[ListRecordsRequest])))
+      .thenReturn(responseWithToken)
+
+    val result = featureStoreManager.listRecords(TEST_FEATURE_GROUP_ARN, maxResults = 1)
+
+    val nextToken = result.get("NextToken").asInstanceOf[String]
+    assertEquals(nextToken, "next-page-token")
+  }
+
+  @Test
+  def listRecordsWithSoftDeletedTest(): Unit = {
+    val result =
+      featureStoreManager.listRecords(TEST_FEATURE_GROUP_ARN, includeSoftDeletedRecords = true)
+
+    verify(mockedSageMakerFeatureStoreRuntimeClient, org.mockito.Mockito.atLeastOnce())
+      .listRecords(any(classOf[ListRecordsRequest]))
+    val identifiers = result.get("RecordIdentifiers").asInstanceOf[java.util.List[String]]
+    assertEquals(identifiers.size(), 2)
   }
 
   @DataProvider


### PR DESCRIPTION
- Add useBatchWriteRecord=false flag to ingestData() (Scala) and ingest_data() (PySpark)
- Implement batchWriteOnlineRecordsForPartition() with 25 records per call
- Map partial failures to specific rows in failedStreamIngestionDataFrame
- Add listRecords() returning java.util.Map for PySpark compatibility
- Bump AWS SDK to 2.46.18 (includes BatchWriteRecord + ListRecords)
- Add apache-client dependency, exclude netty-nio-client to avoid Spark conflicts
- Add Scala unit tests for BWR and listRecords
- Update PySpark unit tests (14 tests passing)

*Issue #, if available:*

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the CONTRIBUTING doc
- [x] I certify that the changes I am introducing will be backward compatible
- [x] I used the commit message format described in CONTRIBUTING doc

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes
- [x] I have verified all code in this commit are well formatted

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.